### PR TITLE
added some tests; setup being able to mock httpclient in tests

### DIFF
--- a/pinboard.net.UnitTests/ExtensionsSpec.cs
+++ b/pinboard.net.UnitTests/ExtensionsSpec.cs
@@ -1,0 +1,53 @@
+﻿using pinboard.net.Util;
+using System.Collections.Generic;
+using Xunit;
+
+namespace pinboard.net.UnitTests
+{
+    public class ExtensionsSpec
+    {
+        [Theory]
+        [InlineData(true, null)]
+        [InlineData(true, "")]
+        [InlineData(true, "        ")]
+        [InlineData(false, "string")]
+        public void IsEmpty_ReturnsExpectedValue_ForGivenString(bool isEmpty, string input)
+        {
+            Assert.Equal(isEmpty, input.IsEmpty());
+        }
+
+        [Theory]
+        [InlineData(false, null)]
+        [InlineData(false, "")]
+        [InlineData(false, "        ")]
+        [InlineData(true, "string")]
+        public void HasValue_ReturnsExpectedValue_ForGivenString(bool isEmpty, string input)
+        {
+            Assert.Equal(isEmpty, input.HasValue());
+        }
+
+        [Fact]
+        public void HasValues_ReturnsTrue_WhenListHasValues()
+        {
+            var list = new List<string> { "one", "two" };
+
+            Assert.True(list.HasValues());
+        }
+
+        [Fact]
+        public void HasValues_ReturnsFalse_WhenListIsEmpty()
+        {
+            var list = new List<string>();
+
+            Assert.False(list.HasValues());
+        }
+
+        [Fact]
+        public void HasValues_ReturnsFalse_WhenListIsNull()
+        {
+            List<string> list = null;
+
+            Assert.False(list.HasValues());
+        }
+    }
+}

--- a/pinboard.net.UnitTests/PostsSpec.cs
+++ b/pinboard.net.UnitTests/PostsSpec.cs
@@ -1,36 +1,89 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using pinboard.net.Endpoints;
 using pinboard.net.Models;
+using RichardSzalay.MockHttp;
 using Xunit;
 
 namespace pinboard.net.UnitTests
 {
-    public class PostsSpec
+    public class PostsSpec : IDisposable
     {
-      [Fact]
+        readonly MockHttpMessageHandler _mockHandler;
+        readonly HttpClient _httpClient;
+        readonly Posts _postRequest;
+
+        public PostsSpec()
+        {
+            _mockHandler = new MockHttpMessageHandler();
+            _httpClient = new HttpClient(_mockHandler, true);
+            _postRequest = new Posts("token", _httpClient);
+        }
+
+        [Fact]
+        public void GetLastUpdate_ReturnsDateAsExpected()
+        {
+            var expectedUpdateTime = "2011-03-24T19:02:07Z";
+            _mockHandler.Expect(GetFullPostsUri("/posts/update"))
+                .WithExactQueryString(BaseQueryString)
+                .Respond("application/json", $"{{'update_time' : '{expectedUpdateTime}'}}");
+
+            var lastPostUpdateDetails = _postRequest.GetLastUpdate().Result;
+
+            Assert.Equal(DateTime.Parse(expectedUpdateTime), lastPostUpdateDetails.UpdateTime);
+        }
+
+        [Fact]
         public void GetShouldThrowWhenCalledWithMoreThan3Tags()
         {
-            var sut = new Posts("", new HttpClient());
+            var sut = new Posts("", _httpClient);
             var tags = new List<string> {"dummy", "dummy", "dummy", "dummy" };
-            Assert.ThrowsAsync<ArgumentException>(() => sut.Get(tags));
+            Assert.ThrowsAsync<ArgumentException>(() => _postRequest.Get(tags));
         }
 
         [Fact]
         public void GetShouldThrowWithInformativeMessage()
         {
             var expectedMessage = "Filter can only contain 3 tags at the most.";
-            var sut = new Posts("", new HttpClient());
             var tags = new List<string> { "dummy", "dummy", "dummy", "dummy" };
-            var exception = Record.ExceptionAsync(() => sut.Get(tags)).Result;
+            var exception = Record.ExceptionAsync(() => _postRequest.Get(tags)).Result;
             Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Fact]
+        public void GetLastUpdate_PassesTagsAsExpected()
+        {
+            var expectedTags = new List<string> { "this", "that", "other" };
+            _mockHandler.Expect(GetFullPostsUri("/posts/get"))
+                .WithExactQueryString($"tag={Uri.EscapeDataString(string.Join(",", expectedTags))}&meta=&{BaseQueryString}")
+                .Respond("application/json", $"{{'posts' : [{{'tags':'{string.Join(" ", expectedTags)}'}}]}}");
+
+            var dayWisePosts = _postRequest.Get(expectedTags).Result;
+
+            Assert.False(dayWisePosts.Posts[0].Tags.Except(expectedTags).Any());
+        }
+
+        [Theory]
+        [InlineData(null, "no")]
+        [InlineData(false, "no")]
+        [InlineData(true, "yes")]
+        public void GetLastUpdate_ReturnsExpectedSharedValue(bool expectedSharedValue, string jsonSharedValue)
+        {
+            _mockHandler.Expect(GetFullPostsUri("/posts/get"))
+                .WithExactQueryString($"meta=&{BaseQueryString}")
+                .Respond("application/json", $"{{'posts' : [{{'shared':'{jsonSharedValue}'}}]}}");
+
+            var dayWisePosts = _postRequest.Get().Result;
+
+            Assert.Equal(expectedSharedValue, dayWisePosts.Posts[0].Shared);
         }
 
         [Fact]
         public void AddShouldThrowWhenUrlIsEmptyWithInformativeMessage()
         {
-            var sut = new Posts("", new HttpClient());
+            var sut = new Posts("", _httpClient);
             var dummyBookmark = new Bookmark();
             var exception = Record.ExceptionAsync(() => sut.Add(dummyBookmark)).Result;
             Assert.Equal("Bookmark's URL cannot be empty", exception.Message);
@@ -39,13 +92,22 @@ namespace pinboard.net.UnitTests
         [Fact]
         public void AddShouldThrowWhenDesciptionIsEmptyWithInformativeMessage()
         {
-            var sut = new Posts("", new HttpClient());
+            var sut = new Posts("", _httpClient);
             var dummyBookmark = new Bookmark
             {
                 Url = "dummy"
             };
             var exception = Record.ExceptionAsync(() => sut.Add(dummyBookmark)).Result;
             Assert.Equal("Bookmark's Description cannot be empty", exception.Message);
+        }
+
+        private string GetFullPostsUri(string path) => $"https://api.pinboard.in/v1{path}";
+
+        private string BaseQueryString => "auth_token=token&format=json";
+
+        public void Dispose()
+        {
+            _httpClient.Dispose();
         }
     }
 }

--- a/pinboard.net.UnitTests/pinboard.net.UnitTests.csproj
+++ b/pinboard.net.UnitTests/pinboard.net.UnitTests.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
     <PackageReference Include="moq" Version="4.7.137" />
+    <PackageReference Include="RichardSzalay.MockHttp" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>

--- a/pinboard.net/PinboardAPI.cs
+++ b/pinboard.net/PinboardAPI.cs
@@ -14,9 +14,9 @@ namespace pinboard.net
         private Users _users;
         private Notes _notes;
 
-        public PinboardAPI(string apiToken)
+        public PinboardAPI(string apiToken, HttpClient httpClient = null)
         {
-            _httpClient = new HttpClient();
+            _httpClient = httpClient ?? new HttpClient();
             _apiToken = apiToken;
         }
 


### PR DESCRIPTION
I didn't add a whole lot of tests, but if you like the direction of the PR, I could always add more before you merge it. I pulled in the `mockhttp` library from NuGet in order to mock out the `HttpClient` calls (making it possible to add more unit tests in the future).

I tried to keep all the changes in the test project. The only change to the pinboard.net project was to make PinboardAPI accept an `HttpClient` (with a null default parameter, so it shouldn't affect anyone currently using it), in order to inject the mocked client.

Let me know if you'd like anything changed in this. I used to have a pinboard account, but no more, so I don't have an auth token to verify my expectations are correct, but according to what I see in the api docs I'm fairly certain I got it right.

#2